### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,14 @@
 - **`PLUGIN_DEV_AGENT.md`** — 开发助手工作流与工具说明（生产工具）。
 
 产品功能与版本说明见根目录 `README.md`、`CHANGELOG.md`。
+
+## Cursor Cloud specific instructions
+
+Javdex 是 Electron 桌面应用（主进程 + preload + React 渲染进程）。Node 22 已就绪，依赖由启动更新脚本 `npm install` 安装（`postinstall` 会用 `electron-rebuild` 针对 Electron 重新编译原生模块 `better-sqlite3`）。标准命令见 `README.md` 与 `package.json` scripts，此处只记非显而易见的云端注意事项：
+
+- **测试 / 类型检查**：`npm test`（= `typecheck:node` + 通过 Electron 以 Node 模式运行的单元测试）。测试用 `ELECTRON_RUN_AS_NODE=1` 运行，**不需要显示器**。本仓库没有 ESLint；“lint”即 `npm run typecheck`（另有 `npm run check:encoding`）。
+- **构建**：`npm run build`（electron-vite build）。
+- **运行 GUI（`npm run dev`）需要显示器**：VM 上有 TigerVNC 桌面在 `DISPLAY=:1`（computer-use 可见）。运行前 `export DISPLAY=:1` 再 `npm run dev`，Electron 窗口才会出现在该桌面上。用 `xvfb-run` 会创建独立的隐藏显示，computer-use 看不到。启动日志里的 `bus.cc ... Failed to connect to the bus` 和 `Exiting GPU process` 报错在无头/VNC 环境下是正常的，可忽略。
+- **数据位置**：`userData` 在 `~/.config/Javdex`；设置为 `~/.config/Javdex/settings.json`，SQLite 库为 `~/.config/Javdex/data/library.db`。要重置状态，停止应用后删除该 db 文件即可（下次启动会重建）。
+- **非交互配置扫描路径**：设置里的“添加路径”按钮打开的是系统原生文件夹选择框，在 VNC 下自动化不可靠。要给 computer-use / 脚本准备可扫描的媒体库，直接预写 `~/.config/Javdex/settings.json`（应用启动前），例如 `{"libraryPaths":["/path/to/media"],"minScanImportDurationMinutes":0}`。`minScanImportDurationMinutes` 默认 30，会跳过短于 30 分钟的文件；测试用短视频时务必设为 0。
+- **可被扫描识别的文件**：扩展名见 `src/main/scanner/codeParser.ts` 的 `VIDEO_EXTENSIONS`；文件名需含可解析的番号（如 `ABC-123.mp4`）才会导入。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the development environment for Javdex (Electron + React + TypeScript + Vite, `better-sqlite3`). No application code was changed — only added Cursor Cloud setup notes to `AGENTS.md`.

## What was done

- Installed dependencies via `npm install` (`postinstall` rebuilds native `better-sqlite3` for Electron).
- Ran typecheck + unit tests: `npm test` → 306 passed, 0 failed.
- Ran `npm run check:encoding` → passed.
- Ran production build: `npm run build` → succeeded.
- Ran the GUI dev app (`npm run dev` on `DISPLAY=:1`) and completed a hello-world: configured a scan path, ran the in-app **扫描并导入** (Scan & Import), and confirmed two videos (`ABC-123`, `DEF-456`) imported into the library (scanned=2, imported=2). Verified independently via the SQLite DB.

## Update script

`npm install` (minimal; native rebuild happens in `postinstall`).

## Hello-world demo

[javdex_scan_import_hello_world.mp4](https://cursor.com/agents/bc-d3bba163-d563-4e16-8ff7-c5e6cc79b89b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjavdex_scan_import_hello_world.mp4)

## Notes for future agents (in AGENTS.md)

- Tests run headless via Electron in Node mode; no display needed.
- GUI dev app needs `DISPLAY=:1` (TigerVNC desktop) so it is visible to tooling; `bus.cc`/GPU log errors are benign.
- The native folder picker is unreliable under VNC — pre-seed `~/.config/Javdex/settings.json` with `libraryPaths` and set `minScanImportDurationMinutes: 0` for short test videos.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3bba163-d563-4e16-8ff7-c5e6cc79b89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3bba163-d563-4e16-8ff7-c5e6cc79b89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

