### PR TITLE
feat: filter and badge actress scrape status in the library (#20)

### DIFF
--- a/src/main/db/actressRepo.test.ts
+++ b/src/main/db/actressRepo.test.ts
@@ -17,6 +17,7 @@ import {
   editActress,
   listActresses,
   listActressesForBatchScrape,
+  listActressPage,
   mergeActresses,
   getActressAvatarSourceInfo,
   getActressDetail,
@@ -223,6 +224,100 @@ describe('actressRepo.listActresses', () => {
     assert.equal(sorted[0]?.main_name, 'Complete')
     assert.equal(sorted[0]?.video_count, 2)
     assert.equal(sorted.find((a) => a.main_name === 'Missing Female')?.video_count, 1)
+  })
+})
+
+describe('actressRepo.listActressPage', () => {
+  /** Complete: success, Missing Female: failed, Missing Male: success, Unknown Gender: unscraped. */
+  function setupStatuses(): void {
+    setupDb()
+    const update = getDb().prepare('UPDATE actresses SET scraped_status = ? WHERE id = ?')
+    update.run(1, 1)
+    update.run(2, 2)
+    update.run(1, 3)
+  }
+
+  it('returns the cumulative status of every actress with per-status counts', () => {
+    setupStatuses()
+
+    const page = listActressPage({ gender: 'all' })
+
+    assert.deepEqual(
+      page.items.map((item) => [item.main_name, item.scraped_status]),
+      [
+        ['Complete', 1],
+        ['Missing Female', 2],
+        ['Missing Male', 1],
+        ['Unknown Gender', 0]
+      ]
+    )
+    assert.deepEqual(page.statusCounts, { all: 4, success: 2, unscraped: 1, failed: 1 })
+  })
+
+  it('filters by each status while keeping the counts of the unfiltered scope', () => {
+    setupStatuses()
+
+    const success = listActressPage({ gender: 'all', status: 'success' })
+    const unscraped = listActressPage({ gender: 'all', status: 'unscraped' })
+    const failed = listActressPage({ gender: 'all', status: 'failed' })
+
+    assert.deepEqual(success.items.map((item) => item.main_name), ['Complete', 'Missing Male'])
+    assert.deepEqual(unscraped.items.map((item) => item.main_name), ['Unknown Gender'])
+    assert.deepEqual(failed.items.map((item) => item.main_name), ['Missing Female'])
+    assert.deepEqual(failed.statusCounts, success.statusCounts)
+  })
+
+  it('combines the status filter with search, gender and sort', () => {
+    setupStatuses()
+    const db = getDb()
+    insertTestVideoWithFile(db, { code: 'A-001', filePath: 'a.mp4', title: 'A', addTime: '2024-01-01' })
+    db.prepare('INSERT INTO video_actress (video_id, actress_id) VALUES (?, ?)').run(1, 2)
+    db.prepare('UPDATE actresses SET scraped_status = 1 WHERE id = 4').run()
+
+    assert.deepEqual(
+      listActressPage({ search: 'Missing', gender: 'all', status: 'success' }).items.map(
+        (item) => item.main_name
+      ),
+      ['Missing Male']
+    )
+    assert.deepEqual(
+      listActressPage({ gender: 'female', status: 'failed' }).items.map((item) => [
+        item.main_name,
+        item.video_count
+      ]),
+      [['Missing Female', 1]]
+    )
+    assert.deepEqual(
+      listActressPage({ gender: 'all', status: 'success', sortBy: 'video_count', sortDir: 'asc' })
+        .items.map((item) => item.main_name),
+      ['Complete', 'Missing Male', 'Unknown Gender']
+    )
+  })
+
+  it('counts statuses within the current search and gender scope', () => {
+    setupStatuses()
+
+    assert.deepEqual(listActressPage({ gender: 'female' }).statusCounts, {
+      all: 2,
+      success: 1,
+      unscraped: 0,
+      failed: 1
+    })
+    assert.deepEqual(listActressPage({ search: 'Missing', gender: 'all' }).statusCounts, {
+      all: 2,
+      success: 1,
+      unscraped: 0,
+      failed: 1
+    })
+  })
+
+  it('treats a missing status as all statuses', () => {
+    setupStatuses()
+
+    assert.deepEqual(
+      listActressPage({ gender: 'all', status: 'all' }).items.map((item) => item.main_name),
+      listActressPage({ gender: 'all' }).items.map((item) => item.main_name)
+    )
   })
 })
 

--- a/src/main/db/actressRepo.ts
+++ b/src/main/db/actressRepo.ts
@@ -15,12 +15,18 @@ import type {
   ActressGender,
   ActressGenderFilter,
   ActressListItem,
+  ActressListPage,
+  ActressListQuery,
   ActressListSortBy,
+  ActressListStatusCounts,
+  ActressListStatusFilter,
   ActressAvatarSourceInfo,
   ActressMergeMainNameFrom,
-  ListSortDir
+  ListSortDir,
+  ScrapedStatus
 } from '@shared/types'
 import { ALL_ACTRESS_SCRAPE_FIELDS, ACTRESS_BATCH_DEFAULT_MISSING_FIELDS } from '@shared/types'
+import { ACTRESS_LIST_STATUS_SCRAPED_STATUS } from '@shared/types'
 import {
   createAvatarCropV1,
   parseAvatarCrop,
@@ -606,13 +612,11 @@ export function listIncompleteProfileActresses(
   })
 }
 
-export function listActresses(
-  search?: string,
-  gender: ActressGenderFilter = 'female',
-  sortBy: ActressListSortBy = 'video_count',
-  sortDir: ListSortDir = 'desc'
-): ActressListItem[] {
-  const db = getDb()
+function buildActressListWhere(
+  search: string | undefined,
+  gender: ActressGenderFilter,
+  status: ActressListStatusFilter
+): { sql: string; params: unknown[] } {
   const conditions: string[] = []
   const params: unknown[] = []
 
@@ -624,8 +628,23 @@ export function listActresses(
     conditions.push('a.gender = ?')
     params.push(gender)
   }
+  if (status !== 'all') {
+    conditions.push('a.scraped_status = ?')
+    params.push(ACTRESS_LIST_STATUS_SCRAPED_STATUS[status])
+  }
 
-  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''
+  return { sql: conditions.length ? `WHERE ${conditions.join(' AND ')}` : '', params }
+}
+
+export function listActresses(
+  search?: string,
+  gender: ActressGenderFilter = 'female',
+  sortBy: ActressListSortBy = 'video_count',
+  sortDir: ListSortDir = 'desc',
+  status: ActressListStatusFilter = 'all'
+): ActressListItem[] {
+  const db = getDb()
+  const { sql: where, params } = buildActressListWhere(search, gender, status)
   const orderBy = buildActressListOrderBy(sortBy, sortDir)
   return db
     .prepare(
@@ -659,6 +678,53 @@ function buildActressListOrderBy(sortBy: ActressListSortBy, sortDir: ListSortDir
     case 'video_count':
     default:
       return `video_count ${dir}, ${tie}`
+  }
+}
+
+const ACTRESS_LIST_STATUS_BY_SCRAPED_STATUS = new Map<
+  ScrapedStatus,
+  Exclude<ActressListStatusFilter, 'all'>
+>(
+  (
+    Object.entries(ACTRESS_LIST_STATUS_SCRAPED_STATUS) as [
+      Exclude<ActressListStatusFilter, 'all'>,
+      ScrapedStatus
+    ][]
+  ).map(([filter, status]) => [status, filter])
+)
+
+/** Actresses per cumulative status, scoped by search and gender but not by the status filter. */
+function countActressListStatuses(
+  search: string | undefined,
+  gender: ActressGenderFilter
+): ActressListStatusCounts {
+  const db = getDb()
+  const { sql: where, params } = buildActressListWhere(search, gender, 'all')
+  const rows = db
+    .prepare(
+      `SELECT a.scraped_status AS status, COUNT(*) AS n
+       FROM actresses a
+       ${where}
+       GROUP BY a.scraped_status`
+    )
+    .all(...params) as Array<{ status: ScrapedStatus; n: number }>
+
+  const counts: ActressListStatusCounts = { all: 0, success: 0, unscraped: 0, failed: 0 }
+  for (const row of rows) {
+    const filter = ACTRESS_LIST_STATUS_BY_SCRAPED_STATUS.get(row.status)
+    if (!filter) continue
+    counts[filter] += row.n
+    counts.all += row.n
+  }
+  return counts
+}
+
+/** Actress list read contract: filtered rows plus the status counts the toolbar shows. */
+export function listActressPage(query: ActressListQuery = {}): ActressListPage {
+  const gender = query.gender ?? 'female'
+  return {
+    items: listActresses(query.search, gender, query.sortBy, query.sortDir, query.status ?? 'all'),
+    statusCounts: countActressListStatuses(query.search, gender)
   }
 }
 

--- a/src/main/db/actressRepo.ts
+++ b/src/main/db/actressRepo.ts
@@ -26,7 +26,7 @@ import type {
   ScrapedStatus
 } from '@shared/types'
 import { ALL_ACTRESS_SCRAPE_FIELDS, ACTRESS_BATCH_DEFAULT_MISSING_FIELDS } from '@shared/types'
-import { ACTRESS_LIST_STATUS_SCRAPED_STATUS } from '@shared/types'
+import { ACTRESS_LIST_STATUS_SCRAPED_STATUS, actressStatusFilterOf } from '@shared/types'
 import {
   createAvatarCropV1,
   parseAvatarCrop,
@@ -681,18 +681,6 @@ function buildActressListOrderBy(sortBy: ActressListSortBy, sortDir: ListSortDir
   }
 }
 
-const ACTRESS_LIST_STATUS_BY_SCRAPED_STATUS = new Map<
-  ScrapedStatus,
-  Exclude<ActressListStatusFilter, 'all'>
->(
-  (
-    Object.entries(ACTRESS_LIST_STATUS_SCRAPED_STATUS) as [
-      Exclude<ActressListStatusFilter, 'all'>,
-      ScrapedStatus
-    ][]
-  ).map(([filter, status]) => [status, filter])
-)
-
 /** Actresses per cumulative status, scoped by search and gender but not by the status filter. */
 function countActressListStatuses(
   search: string | undefined,
@@ -711,9 +699,7 @@ function countActressListStatuses(
 
   const counts: ActressListStatusCounts = { all: 0, success: 0, unscraped: 0, failed: 0 }
   for (const row of rows) {
-    const filter = ACTRESS_LIST_STATUS_BY_SCRAPED_STATUS.get(row.status)
-    if (!filter) continue
-    counts[filter] += row.n
+    counts[actressStatusFilterOf(row.status)] += row.n
     counts.all += row.n
   }
   return counts

--- a/src/main/db/actressRepo.ts
+++ b/src/main/db/actressRepo.ts
@@ -25,8 +25,12 @@ import type {
   ListSortDir,
   ScrapedStatus
 } from '@shared/types'
-import { ALL_ACTRESS_SCRAPE_FIELDS, ACTRESS_BATCH_DEFAULT_MISSING_FIELDS } from '@shared/types'
-import { ACTRESS_LIST_STATUS_SCRAPED_STATUS, actressStatusFilterOf } from '@shared/types'
+import {
+  ALL_ACTRESS_SCRAPE_FIELDS,
+  ACTRESS_BATCH_DEFAULT_MISSING_FIELDS,
+  ACTRESS_LIST_STATUS_SCRAPED_STATUS,
+  actressStatusFilterOf
+} from '@shared/types'
 import {
   createAvatarCropV1,
   parseAvatarCrop,

--- a/src/main/ipc/actressHandlers.ts
+++ b/src/main/ipc/actressHandlers.ts
@@ -7,6 +7,8 @@ import type {
   ActressGenderFilter,
   ActressAvatarSourceInfo,
   ActressListItem,
+  ActressListPage,
+  ActressListQuery,
   ActressListSortBy,
   ActressMergeInput,
   ListSortDir
@@ -19,6 +21,7 @@ import {
   getActressDetail,
   getActressAvatarSourceInfo,
   listActresses,
+  listActressPage,
   mergeActresses,
   setActressPosterPath
 } from '../db/actressRepo'
@@ -38,6 +41,11 @@ export function registerActressHandlers(): void {
       sortBy?: ActressListSortBy,
       sortDir?: ListSortDir
     ): ActressListItem[] => listActresses(search, gender, sortBy, sortDir)
+  )
+
+  registerHandler(
+    IPC.ACTRESS_LIST_PAGE,
+    (_e, query?: ActressListQuery): ActressListPage => listActressPage(query)
   )
 
   registerHandler(IPC.ACTRESS_GET, (_e, id: number): ActressDetail | null =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -25,6 +25,8 @@ import type {
   ActressEditInput,
   ActressGenderFilter,
   ActressListItem,
+  ActressListPage,
+  ActressListQuery,
   ActressListSortBy,
   ActressMergeInput,
   ListSortDir,
@@ -175,6 +177,7 @@ const api = {
       sortBy?: ActressListSortBy,
       sortDir?: ListSortDir
     ) => invoke<ActressListItem[]>(IPC.ACTRESS_LIST, search, gender, sortBy, sortDir),
+    listPage: (query: ActressListQuery) => invoke<ActressListPage>(IPC.ACTRESS_LIST_PAGE, query),
     get: (id: number) => invoke<ActressDetail | null>(IPC.ACTRESS_GET, id),
     getAvatarSourceInfo: (id: number) =>
       invoke<ActressAvatarSourceInfo | null>(IPC.ACTRESS_AVATAR_SOURCE_INFO, id),

--- a/src/renderer/src/components/ActressStatusBadge.tsx
+++ b/src/renderer/src/components/ActressStatusBadge.tsx
@@ -1,0 +1,27 @@
+import type { ScrapedStatus } from '@shared/types'
+import { actressStatusFilterOf } from '@shared/types'
+import { ACTRESS_STATUS_FILTER_LABELS } from './ActressStatusFilterPopover'
+
+/**
+ * Corner badge for actresses that still need attention.
+ * A successful cumulative scrape is the quiet default and stays unbadged.
+ */
+export default function ActressStatusBadge({
+  status
+}: {
+  status: ScrapedStatus
+}): JSX.Element | null {
+  const filter = actressStatusFilterOf(status)
+  if (filter === 'success') return null
+
+  const label = ACTRESS_STATUS_FILTER_LABELS[filter]
+  return (
+    <span
+      className={`actress-status-badge actress-status-badge--${filter}`}
+      role="img"
+      aria-label={`刮削状态：${label}`}
+    >
+      {label}
+    </span>
+  )
+}

--- a/src/renderer/src/components/ActressStatusFilterPopover.tsx
+++ b/src/renderer/src/components/ActressStatusFilterPopover.tsx
@@ -1,0 +1,69 @@
+import type { RefObject } from 'react'
+import type { ActressListStatusCounts, ActressListStatusFilter } from '@shared/types'
+import FloatingLayer from './FloatingLayer'
+import { useEscapeKey } from '../hooks/useEscapeKey'
+
+export const ACTRESS_STATUS_FILTER_LABELS: Record<ActressListStatusFilter, string> = {
+  all: '全部状态',
+  success: '刮削成功',
+  unscraped: '未刮削',
+  failed: '刮削失败'
+}
+
+const ACTRESS_STATUS_FILTER_ORDER: ActressListStatusFilter[] = [
+  'all',
+  'success',
+  'unscraped',
+  'failed'
+]
+
+interface Props {
+  open: boolean
+  anchorRef: RefObject<HTMLElement | null>
+  value: ActressListStatusFilter
+  counts: ActressListStatusCounts
+  onChange: (status: ActressListStatusFilter) => void
+  onClose: () => void
+}
+
+/** Cumulative scrape status filter for the actress list toolbar. */
+export default function ActressStatusFilterPopover({
+  open,
+  anchorRef,
+  value,
+  counts,
+  onChange,
+  onClose
+}: Props): JSX.Element | null {
+  useEscapeKey(onClose, open)
+
+  return (
+    <FloatingLayer
+      open={open}
+      anchorRef={anchorRef}
+      side="bottom"
+      align="end"
+      offset={6}
+      className="status-filter-popover"
+      onClose={onClose}
+    >
+      <div className="status-filter-options" role="group" aria-label="刮削状态">
+        {ACTRESS_STATUS_FILTER_ORDER.map((status) => (
+          <button
+            key={status}
+            type="button"
+            className={`status-filter-option${status === value ? ' is-active' : ''}`}
+            aria-pressed={status === value}
+            onClick={() => {
+              onChange(status)
+              onClose()
+            }}
+          >
+            <span>{ACTRESS_STATUS_FILTER_LABELS[status]}</span>
+            <span className="status-filter-option-count">{counts[status]}</span>
+          </button>
+        ))}
+      </div>
+    </FloatingLayer>
+  )
+}

--- a/src/renderer/src/components/ActressStatusFilterPopover.tsx
+++ b/src/renderer/src/components/ActressStatusFilterPopover.tsx
@@ -45,9 +45,12 @@ export default function ActressStatusFilterPopover({
       align="end"
       offset={6}
       className="status-filter-popover"
+      role="dialog"
+      ariaLabel="刮削状态"
       onClose={onClose}
     >
-      <div className="status-filter-options" role="group" aria-label="刮削状态">
+      <h3 className="status-filter-popover-title">刮削状态</h3>
+      <div className="status-filter-options">
         {ACTRESS_STATUS_FILTER_ORDER.map((status) => (
           <button
             key={status}

--- a/src/renderer/src/components/FloatingLayer.tsx
+++ b/src/renderer/src/components/FloatingLayer.tsx
@@ -12,6 +12,7 @@ interface FloatingLayerProps {
   offset?: number
   className?: string
   role?: string
+  ariaLabel?: string
   id?: string
   onClose?: () => void
   ignoreCloseRefs?: Array<RefObject<HTMLElement | null>>
@@ -26,6 +27,7 @@ export default function FloatingLayer({
   offset,
   className,
   role,
+  ariaLabel,
   id,
   onClose,
   ignoreCloseRefs = [],
@@ -66,6 +68,7 @@ export default function FloatingLayer({
       id={id}
       className={className}
       role={role}
+      aria-label={ariaLabel}
       style={{
         position: 'fixed',
         top: coords?.top ?? -10000,

--- a/src/renderer/src/listView/listQueryParams.ts
+++ b/src/renderer/src/listView/listQueryParams.ts
@@ -1,4 +1,11 @@
-import type { ActressGenderFilter, ScrapedStatus, VideoQuery, ActressListSortBy, ListSortDir } from '@shared/types'
+import type {
+  ActressGenderFilter,
+  ActressListStatusFilter,
+  ScrapedStatus,
+  VideoQuery,
+  ActressListSortBy,
+  ListSortDir
+} from '@shared/types'
 import { ACTRESS_LIST_DEFAULTS } from '@shared/types'
 
 /** Shared list URL keys (library, actresses, facet list). */
@@ -21,6 +28,19 @@ export const LIBRARY_DEFAULTS = {
 }
 
 export const ACTRESS_DEFAULT_GENDER: ActressGenderFilter = ACTRESS_LIST_DEFAULTS.gender
+
+/** All statuses is the default and is never written to the URL. */
+export const ACTRESS_DEFAULT_STATUS: ActressListStatusFilter = 'all'
+
+export function parseActressStatus(raw: string | null): ActressListStatusFilter {
+  if (raw === 'success' || raw === 'unscraped' || raw === 'failed') return raw
+  return ACTRESS_DEFAULT_STATUS
+}
+
+/** URL value for a status filter; `null` drops the param so all statuses stay implicit. */
+export function actressStatusParam(status: ActressListStatusFilter): string | null {
+  return status === ACTRESS_DEFAULT_STATUS ? null : status
+}
 
 export function parseActressSort(
   rawSort: string | null,
@@ -120,6 +140,7 @@ export function actressQueryHash(params: URLSearchParams): string {
   return hashListQuery({
     q: (params.get(LIST_PARAM.q) ?? '').trim(),
     gender: parseGender(params.get(LIST_PARAM.gender)),
+    status: parseActressStatus(params.get(LIST_PARAM.status)),
     sort: sortBy,
     dir: sortDir
   })

--- a/src/renderer/src/listView/primaryNavigationMemory.ts
+++ b/src/renderer/src/listView/primaryNavigationMemory.ts
@@ -18,7 +18,13 @@ const SEARCH_KEYS_BY_ROOT: Record<string, readonly string[]> = {
     LIST_PARAM.status,
     LIST_PARAM.year
   ],
-  '/actresses': [LIST_PARAM.q, LIST_PARAM.gender, LIST_PARAM.sort, LIST_PARAM.dir],
+  '/actresses': [
+    LIST_PARAM.q,
+    LIST_PARAM.gender,
+    LIST_PARAM.status,
+    LIST_PARAM.sort,
+    LIST_PARAM.dir
+  ],
   '/playlists': [LIST_PARAM.q]
 }
 

--- a/src/renderer/src/listView/routeContracts.test.ts
+++ b/src/renderer/src/listView/routeContracts.test.ts
@@ -14,7 +14,14 @@ import {
   parseFacetVideoPath
 } from './facetRoutes'
 import { libraryVideoActressPath, libraryVideoDetailPath, parseLibraryVideoPath } from './libraryRoutes'
-import { navigateToFacetDetail } from './listNavigation'
+import { navigateToActressDetail, navigateToActressList, navigateToFacetDetail } from './listNavigation'
+import {
+  actressQueryHash,
+  actressStatusParam,
+  LIST_PARAM,
+  parseActressStatus,
+  patchSearchParams
+} from './listQueryParams'
 import {
   clearPrimaryNavigationMemory,
   forgetPrimaryListLocation,
@@ -77,6 +84,91 @@ describe('route builders and parsers', () => {
     assert.equal(parseLibraryVideoPath('/detail/not-a-number'), null)
     assert.equal(parseActressVideoPath('/actresses/x'), null)
     assert.equal(parsePlaylistVideoPath('/playlists/x'), null)
+  })
+})
+
+describe('actress status filter query contract', () => {
+  it('parses the canonical status values and treats anything else as all', () => {
+    assert.equal(parseActressStatus('success'), 'success')
+    assert.equal(parseActressStatus('unscraped'), 'unscraped')
+    assert.equal(parseActressStatus('failed'), 'failed')
+    assert.equal(parseActressStatus(null), 'all')
+    assert.equal(parseActressStatus('all'), 'all')
+    assert.equal(parseActressStatus('1'), 'all')
+    assert.equal(parseActressStatus('scraped'), 'all')
+  })
+
+  it('omits the param for all and writes the canonical value otherwise', () => {
+    assert.equal(actressStatusParam('all'), null)
+    assert.equal(actressStatusParam('unscraped'), 'unscraped')
+
+    const applied = patchSearchParams(new URLSearchParams('q=sara&gender=all'), {
+      [LIST_PARAM.status]: actressStatusParam('failed')
+    })
+    assert.equal(applied.toString(), 'q=sara&gender=all&status=failed')
+
+    const removed = patchSearchParams(applied, {
+      [LIST_PARAM.status]: actressStatusParam('all')
+    })
+    assert.equal(removed.toString(), 'q=sara&gender=all')
+  })
+
+  it('includes status in the list query identity and ignores invalid values', () => {
+    const unscraped = actressQueryHash(new URLSearchParams('status=unscraped'))
+    const failed = actressQueryHash(new URLSearchParams('status=failed'))
+    const invalid = actressQueryHash(new URLSearchParams('status=bogus'))
+    const all = actressQueryHash(new URLSearchParams(''))
+
+    assert.notEqual(unscraped, failed)
+    assert.notEqual(unscraped, all)
+    assert.equal(invalid, all)
+  })
+
+  it('keeps search, gender and sort identity while only the status changes', () => {
+    const base = new URLSearchParams('q=sara&gender=all&sort=age&dir=asc')
+    const withStatus = patchSearchParams(base, { [LIST_PARAM.status]: 'unscraped' })
+
+    assert.equal(withStatus.get(LIST_PARAM.q), 'sara')
+    assert.equal(withStatus.get(LIST_PARAM.gender), 'all')
+    assert.equal(withStatus.get(LIST_PARAM.sort), 'age')
+    assert.equal(withStatus.get(LIST_PARAM.dir), 'asc')
+    assert.notEqual(actressQueryHash(withStatus), actressQueryHash(base))
+  })
+
+  it('round-trips the status query through actress detail and back', () => {
+    const destinations: unknown[] = []
+    const navigate = ((to: unknown) => {
+      destinations.push(to)
+    }) as NavigateFunction
+    const listLocation = {
+      pathname: '/actresses',
+      search: '?q=sara&gender=all&status=failed',
+      hash: '',
+      state: null,
+      key: 'test'
+    } as Location
+
+    navigateToActressDetail(navigate, listLocation, 8)
+    assert.deepEqual(destinations[0], {
+      pathname: '/actresses/8',
+      search: '?q=sara&gender=all&status=failed'
+    })
+
+    navigateToActressList(navigate, { ...listLocation, pathname: '/actresses/8' } as Location)
+    assert.deepEqual(destinations[1], {
+      pathname: '/actresses',
+      search: 'q=sara&gender=all&status=failed'
+    })
+  })
+
+  it('remembers the actress status filter across primary navigation', () => {
+    clearPrimaryNavigationMemory()
+    rememberPrimaryListLocation('/actresses/8', '?q=sara&status=unscraped')
+
+    assert.deepEqual(primaryNavigationTarget('/actresses'), {
+      pathname: '/actresses',
+      search: '?q=sara&status=unscraped'
+    })
   })
 })
 

--- a/src/renderer/src/pages/ActressesPage.tsx
+++ b/src/renderer/src/pages/ActressesPage.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useMatch, useSearchParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { SearchCheck, SearchX, Trash2, Users } from 'lucide-react'
+import { ChevronDown, SearchCheck, SearchX, Trash2, Users } from 'lucide-react'
 import {
   ACTRESS_LIST_DEFAULTS,
   ACTRESS_SCRAPE_FIELD_OPTIONS,
@@ -9,6 +9,8 @@ import {
   ALL_ACTRESS_SCRAPE_FIELDS,
   type ActressListItem,
   type ActressListSortBy,
+  type ActressListStatusCounts,
+  type ActressListStatusFilter,
   type ActressScrapeField,
   type ActressScrapeUpdateMode
 } from '@shared/types'
@@ -25,10 +27,17 @@ import ListToolbar from '../components/ListToolbar'
 import SelectionToolbar from '../components/SelectionToolbar'
 import SortSwitch, { type SortSwitchOption } from '../components/SortSwitch'
 import ScrapeFieldsModal from '../components/ScrapeFieldsModal'
+import ActressStatusBadge from '../components/ActressStatusBadge'
+import ActressStatusFilterPopover, {
+  ACTRESS_STATUS_FILTER_LABELS
+} from '../components/ActressStatusFilterPopover'
 import {
   actressQueryHash,
+  actressStatusParam,
+  ACTRESS_DEFAULT_STATUS,
   LIST_PARAM,
   parseActressSort,
+  parseActressStatus,
   parseGender,
   patchSearchParams
 } from '../listView/listQueryParams'
@@ -54,8 +63,6 @@ import {
   isMaintenanceHintDismissed,
   MAINTENANCE_HINT_KEYS
 } from '../utils/maintenanceHints'
-import { settingsPath } from '../settings/settingsRoutes'
-
 const ACTRESS_SORT_OPTIONS: SortSwitchOption<ActressListSortBy>[] = [
   { value: 'video_count', label: '影片', title: '本地影片数' },
   { value: 'gallery', label: '写真', title: '写真数量' },
@@ -74,6 +81,13 @@ const ACTRESS_SORT_LABELS: Record<ActressListSortBy, string> = {
   gallery: '写真数',
   age: '年龄',
   cup_size: '罩杯'
+}
+
+const EMPTY_STATUS_COUNTS: ActressListStatusCounts = {
+  all: 0,
+  success: 0,
+  unscraped: 0,
+  failed: 0
 }
 
 export default function ActressesPage(): JSX.Element {
@@ -101,6 +115,7 @@ export default function ActressesPage(): JSX.Element {
   }, [debouncedQ, urlQ, setSearchParams])
 
   const genderFilter = parseGender(searchParams.get(LIST_PARAM.gender))
+  const statusFilter = parseActressStatus(searchParams.get(LIST_PARAM.status))
   const { sortBy, sortDir } = parseActressSort(
     searchParams.get(LIST_PARAM.sort),
     searchParams.get(LIST_PARAM.dir)
@@ -120,18 +135,28 @@ export default function ActressesPage(): JSX.Element {
   const [showBulkScrape, setShowBulkScrape] = useState(false)
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const statusFilterBtnRef = useRef<HTMLButtonElement>(null)
+  const [statusFilterOpen, setStatusFilterOpen] = useState(false)
 
   const dismissOverlays = useCallback(() => {
     setPendingDelete(null)
     setShowBulkScrape(false)
     setConfirmBulkDelete(false)
+    setStatusFilterOpen(false)
   }, [])
 
   useDismissOverlaysOnNavigate(dismissOverlays, location.pathname)
 
   const listQuery = useQuery({
     queryKey: actressKeys.list(queryHash, debouncedQ.trim(), genderFilter, sortBy, sortDir),
-    queryFn: () => api.actresses.list(debouncedQ.trim(), genderFilter, sortBy, sortDir),
+    queryFn: () =>
+      api.actresses.listPage({
+        search: debouncedQ.trim(),
+        gender: genderFilter,
+        status: statusFilter,
+        sortBy,
+        sortDir
+      }),
     placeholderData: (prev) => prev
   })
 
@@ -149,7 +174,8 @@ export default function ActressesPage(): JSX.Element {
 
   useListSurfaceRefetch(detailOpen, refetchActressSurface)
 
-  const items = listQuery.data ?? []
+  const items = listQuery.data?.items ?? []
+  const statusCounts = listQuery.data?.statusCounts ?? EMPTY_STATUS_COUNTS
   const loading = listQuery.isLoading && items.length === 0
   const isFetching = listQuery.isFetching
 
@@ -268,18 +294,33 @@ export default function ActressesPage(): JSX.Element {
     }
   }
 
+  const setStatusFilter = (status: ActressListStatusFilter): void => {
+    patchParams({ [LIST_PARAM.status]: actressStatusParam(status) })
+  }
+
   const hasNonDefaultSort =
     sortBy !== ACTRESS_LIST_DEFAULTS.sortBy || sortDir !== ACTRESS_LIST_DEFAULTS.sortDir
-  const hasAppliedFilters = genderFilter !== ACTRESS_LIST_DEFAULTS.gender || hasNonDefaultSort
+  const hasAppliedFilters =
+    genderFilter !== ACTRESS_LIST_DEFAULTS.gender ||
+    statusFilter !== ACTRESS_DEFAULT_STATUS ||
+    hasNonDefaultSort
   const resetFilters = (): void => {
     forgetPrimaryListLocation(ROUTE_PATH.actresses)
     patchParams({
       [LIST_PARAM.gender]: null,
+      [LIST_PARAM.status]: null,
       [LIST_PARAM.sort]: null,
       [LIST_PARAM.dir]: null
     })
   }
   const appliedFilters: AppliedFilterItem[] = []
+  if (statusFilter !== ACTRESS_DEFAULT_STATUS) {
+    appliedFilters.push({
+      key: 'status',
+      label: ACTRESS_STATUS_FILTER_LABELS[statusFilter],
+      onRemove: () => setStatusFilter(ACTRESS_DEFAULT_STATUS)
+    })
+  }
   if (genderFilter !== ACTRESS_LIST_DEFAULTS.gender) {
     appliedFilters.push({
       key: 'gender',
@@ -343,6 +384,33 @@ export default function ActressesPage(): JSX.Element {
             }}
             controls={
               <>
+                <button
+                  ref={statusFilterBtnRef}
+                  type="button"
+                  className={`btn btn-sm list-filter-btn${statusFilterOpen ? ' list-filter-btn--open' : ''}${statusFilter !== ACTRESS_DEFAULT_STATUS ? ' list-filter-btn--active' : ''}`}
+                  onClick={() => setStatusFilterOpen((open) => !open)}
+                  aria-expanded={statusFilterOpen}
+                  aria-haspopup="dialog"
+                >
+                  <span className="list-filter-btn-label">
+                    {statusFilter === ACTRESS_DEFAULT_STATUS
+                      ? '筛选'
+                      : ACTRESS_STATUS_FILTER_LABELS[statusFilter]}
+                  </span>
+                  <ChevronDown
+                    {...UI_ICON_SM}
+                    className={`list-filter-chevron${statusFilterOpen ? ' is-open' : ''}`}
+                    aria-hidden
+                  />
+                </button>
+                <ActressStatusFilterPopover
+                  open={statusFilterOpen}
+                  anchorRef={statusFilterBtnRef}
+                  value={statusFilter}
+                  counts={statusCounts}
+                  onChange={setStatusFilter}
+                  onClose={() => setStatusFilterOpen(false)}
+                />
                 <div className="mode-toggle" role="group" aria-label="性别筛选">
                   <button
                     type="button"
@@ -409,9 +477,9 @@ export default function ActressesPage(): JSX.Element {
                 ? '批量刮削任务进行中，完成后将自动更新列表。'
                 : '可批量补全头像、简介与身体数据。'
             }
-            secondaryLabel="前往设置"
+            secondaryLabel="查看未刮削"
             primaryLabel={actressBatchActive ? '刮削进行中…' : '一键刮削'}
-            onSecondary={() => navigate(settingsPath('overview', 'status'))}
+            onSecondary={() => setStatusFilter('unscraped')}
             onPrimary={() => void startUnscrapedBatch()}
             onDismiss={dismissUnscrapedBanner}
             primaryDisabled={actressBatchActive || !defaultScraper}
@@ -446,7 +514,7 @@ export default function ActressesPage(): JSX.Element {
               title={emptyDueToFilter ? '没有匹配的演员' : '暂无演员数据'}
               description={
                 emptyDueToFilter
-                  ? '调整搜索、性别或排序条件后再试。'
+                  ? '调整搜索、刮削状态、性别或排序条件后再试。'
                   : '刮削影片后将自动归纳演员。'
               }
             />
@@ -482,7 +550,10 @@ export default function ActressesPage(): JSX.Element {
                         navigateToActressDetail(navigate, location, a.id)
                       }}
                     >
-                      <ActressAvatar src={avatar} name={a.main_name} gender={a.gender} />
+                      <span className="actress-card-avatar">
+                        <ActressAvatar src={avatar} name={a.main_name} gender={a.gender} />
+                        <ActressStatusBadge status={a.scraped_status} />
+                      </span>
                       <ActressName name={a.main_name} gender={a.gender} className="actress-name" />
                       <div className="actress-count">{a.video_count} 部</div>
                     </button>

--- a/src/renderer/src/pages/ActressesPage.tsx
+++ b/src/renderer/src/pages/ActressesPage.tsx
@@ -63,6 +63,7 @@ import {
   isMaintenanceHintDismissed,
   MAINTENANCE_HINT_KEYS
 } from '../utils/maintenanceHints'
+
 const ACTRESS_SORT_OPTIONS: SortSwitchOption<ActressListSortBy>[] = [
   { value: 'video_count', label: '影片', title: '本地影片数' },
   { value: 'gallery', label: '写真', title: '写真数量' },
@@ -300,10 +301,9 @@ export default function ActressesPage(): JSX.Element {
 
   const hasNonDefaultSort =
     sortBy !== ACTRESS_LIST_DEFAULTS.sortBy || sortDir !== ACTRESS_LIST_DEFAULTS.sortDir
+  const hasStatusFilter = statusFilter !== ACTRESS_DEFAULT_STATUS
   const hasAppliedFilters =
-    genderFilter !== ACTRESS_LIST_DEFAULTS.gender ||
-    statusFilter !== ACTRESS_DEFAULT_STATUS ||
-    hasNonDefaultSort
+    genderFilter !== ACTRESS_LIST_DEFAULTS.gender || hasStatusFilter || hasNonDefaultSort
   const resetFilters = (): void => {
     forgetPrimaryListLocation(ROUTE_PATH.actresses)
     patchParams({
@@ -314,7 +314,7 @@ export default function ActressesPage(): JSX.Element {
     })
   }
   const appliedFilters: AppliedFilterItem[] = []
-  if (statusFilter !== ACTRESS_DEFAULT_STATUS) {
+  if (hasStatusFilter) {
     appliedFilters.push({
       key: 'status',
       label: ACTRESS_STATUS_FILTER_LABELS[statusFilter],
@@ -387,16 +387,12 @@ export default function ActressesPage(): JSX.Element {
                 <button
                   ref={statusFilterBtnRef}
                   type="button"
-                  className={`btn btn-sm list-filter-btn${statusFilterOpen ? ' list-filter-btn--open' : ''}${statusFilter !== ACTRESS_DEFAULT_STATUS ? ' list-filter-btn--active' : ''}`}
+                  className={`btn btn-sm list-filter-btn${statusFilterOpen ? ' list-filter-btn--open' : ''}${hasStatusFilter ? ' list-filter-btn--active' : ''}`}
                   onClick={() => setStatusFilterOpen((open) => !open)}
                   aria-expanded={statusFilterOpen}
                   aria-haspopup="dialog"
                 >
-                  <span className="list-filter-btn-label">
-                    {statusFilter === ACTRESS_DEFAULT_STATUS
-                      ? '筛选'
-                      : ACTRESS_STATUS_FILTER_LABELS[statusFilter]}
-                  </span>
+                  <span className="list-filter-btn-label">筛选</span>
                   <ChevronDown
                     {...UI_ICON_SM}
                     className={`list-filter-chevron${statusFilterOpen ? ' is-open' : ''}`}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1248,7 +1248,8 @@ textarea.text-input {
   position: relative;
 }
 
-.library-filter-btn {
+.library-filter-btn,
+.list-filter-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1256,17 +1257,21 @@ textarea.text-input {
 }
 
 .library-filter-btn--active,
-.library-filter-btn--open {
+.library-filter-btn--open,
+.list-filter-btn--active,
+.list-filter-btn--open {
   border-color: var(--accent);
   background: var(--accent-soft);
   color: var(--accent-hover);
 }
 
-.library-filter-btn-label {
+.library-filter-btn-label,
+.list-filter-btn-label {
   font-weight: 500;
 }
 
-.library-filter-chevron {
+.library-filter-chevron,
+.list-filter-chevron {
   display: inline-flex;
   align-items: center;
   margin-left: 2px;
@@ -1276,9 +1281,66 @@ textarea.text-input {
   transition: transform 0.18s ease, color 0.15s;
 }
 .library-filter-btn--open .library-filter-chevron,
-.library-filter-chevron.is-open {
+.library-filter-chevron.is-open,
+.list-filter-btn--open .list-filter-chevron,
+.list-filter-chevron.is-open {
   transform: rotate(180deg);
   color: var(--accent-hover);
+}
+
+/* Single-choice filter popover (actress cumulative scrape status). */
+.status-filter-popover {
+  width: 188px;
+  padding: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-panel);
+  box-shadow: var(--shadow-elevated);
+}
+
+.status-filter-options {
+  display: grid;
+  gap: 2px;
+}
+
+.status-filter-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: var(--control-h-sm);
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-align: left;
+}
+
+.status-filter-option:hover {
+  background: var(--surface-elevated);
+  color: var(--text-primary);
+}
+
+.status-filter-option:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: -2px;
+}
+
+.status-filter-option.is-active {
+  border-color: var(--border-accent);
+  background: var(--surface-selected);
+  color: var(--text-accent);
+}
+
+.status-filter-option-count {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.status-filter-option.is-active .status-filter-option-count {
+  color: inherit;
 }
 
 .sort-switch {
@@ -5190,6 +5252,42 @@ button.tag-chip--custom-pick {
 }
 .actress-card:hover .actress-avatar {
   border-color: color-mix(in srgb, var(--accent) 42%, var(--border-subtle));
+}
+/* Avatar-anchored status corner: never overlaps the select / delete controls. */
+.actress-card-avatar {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+}
+.actress-status-badge {
+  position: absolute;
+  right: -8px;
+  bottom: -2px;
+  max-width: calc(100% + 16px);
+  padding: 0 5px;
+  border: 2px solid var(--surface-panel);
+  border-radius: 999px;
+  background: var(--surface-control);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.actress-status-badge--unscraped {
+  background: var(--surface-warning);
+  border-color: var(--surface-panel);
+  color: var(--text-warning);
+}
+.actress-status-badge--failed {
+  background: var(--surface-danger);
+  border-color: var(--surface-panel);
+  color: var(--text-danger);
+}
+.actress-card:hover .actress-status-badge {
+  border-color: var(--surface-elevated);
 }
 .actress-card .actress-avatar {
   position: relative;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1298,6 +1298,15 @@ textarea.text-input {
   box-shadow: var(--shadow-elevated);
 }
 
+.status-filter-popover-title {
+  margin: 0;
+  padding: 6px 10px 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
 .status-filter-options {
   display: grid;
   gap: 2px;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -58,6 +58,7 @@ export const IPC = {
 
   // Actresses
   ACTRESS_LIST: 'actress:list',
+  ACTRESS_LIST_PAGE: 'actress:listPage',
   ACTRESS_GET: 'actress:get',
   ACTRESS_AVATAR_SOURCE_INFO: 'actress:avatarSourceInfo',
   ACTRESS_EDIT: 'actress:edit',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -219,6 +219,34 @@ export interface ActressListItem extends Actress {
   video_count: number
 }
 
+/** Canonical actress library status filter vocabulary (also the URL values). */
+export type ActressListStatusFilter = 'all' | 'success' | 'unscraped' | 'failed'
+
+export const ACTRESS_LIST_STATUS_SCRAPED_STATUS: Record<
+  Exclude<ActressListStatusFilter, 'all'>,
+  ScrapedStatus
+> = {
+  unscraped: 0,
+  success: 1,
+  failed: 2
+}
+
+export interface ActressListQuery {
+  search?: string
+  gender?: ActressGenderFilter
+  status?: ActressListStatusFilter
+  sortBy?: ActressListSortBy
+  sortDir?: ListSortDir
+}
+
+/** Actresses per cumulative status within the current search and gender scope. */
+export type ActressListStatusCounts = Record<ActressListStatusFilter, number>
+
+export interface ActressListPage {
+  items: ActressListItem[]
+  statusCounts: ActressListStatusCounts
+}
+
 /** Read-only source metadata used by renderer-side smart avatar composition. */
 export interface ActressAvatarSourceInfo {
   assetPath: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -231,6 +231,25 @@ export const ACTRESS_LIST_STATUS_SCRAPED_STATUS: Record<
   failed: 2
 }
 
+const ACTRESS_LIST_STATUS_BY_SCRAPED_STATUS = new Map<
+  ScrapedStatus,
+  Exclude<ActressListStatusFilter, 'all'>
+>(
+  (
+    Object.entries(ACTRESS_LIST_STATUS_SCRAPED_STATUS) as [
+      Exclude<ActressListStatusFilter, 'all'>,
+      ScrapedStatus
+    ][]
+  ).map(([filter, status]) => [status, filter])
+)
+
+/** Filter vocabulary for a stored cumulative status value. */
+export function actressStatusFilterOf(
+  status: ScrapedStatus
+): Exclude<ActressListStatusFilter, 'all'> {
+  return ACTRESS_LIST_STATUS_BY_SCRAPED_STATUS.get(status) ?? 'unscraped'
+}
+
 export interface ActressListQuery {
   search?: string
   gender?: ActressGenderFilter


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #20 (part of the #16 spec). Built in parallel with #19 and #21.

## What changed
- `types.ts`: `ActressListStatusFilter`, `ActressListQuery`, `ActressListStatusCounts`, `ActressListPage`, `ACTRESS_LIST_STATUS_SCRAPED_STATUS` + `actressStatusFilterOf()` (single source of truth for `success/unscraped/failed` ↔ `1/0/2`).
- `actressRepo`: `buildActressListWhere()` (search + gender + status), optional `status` arg on `listActresses`, new `listActressPage()` returning items + per-status counts (counts scoped by search/gender, not by status).
- New additive IPC `actress:listPage` (channel/handler/`api.actresses.listPage`); old `actress:list` untouched.
- Route/query: `parseActressStatus()`, `actressStatusParam()`, status folded into `actressQueryHash`, and into `/actresses` primary-nav memory. Canonical URL `status=success|unscraped|failed`; `all` omits the param; invalid → all.
- UI: `ActressStatusFilterPopover` (全部/成功/未刮削/失败 + counts, on existing `FloatingLayer`), `ActressStatusBadge` (avatar corner badge, nothing for 刮削成功), `ActressesPage` wiring (removable status chip, reset clears status, maintenance banner 查看未刮削 → `status=unscraped`). Styles use existing semantic tokens.

## Tests
- `routeContracts.test.ts` (+6): canonical parse, invalid→all, serialize/remove, status changes identity while q/gender/sort/dir survive, detail round-trip, nav memory.
- `actressRepo.test.ts` (+5): cumulative status + counts, each filter with counts independent of the status filter, status × search/gender/sort, counts scoped by search/gender, omitted status = all.

## Gates (all green)
- targeted: 66 pass; `npm test`: 362 pass / 0 fail; `typecheck:web` clean; `check:encoding` passed; `build` ✓

## Notes
- Shared wiring edits kept additive for trivial integration with #19/#21.
- GUI smoke (filter/badge/selection-mode) deferred to integration (single shared display); covered by route-contract + repo tests. Verify badge placement vs multi-select/delete controls at the narrowest column, and popover counts refreshing after a batch scrape.
- Same pre-existing avatar flaky test flagged as in #19.

Closes #20
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3bba163-d563-4e16-8ff7-c5e6cc79b89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3bba163-d563-4e16-8ff7-c5e6cc79b89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

