### PR TITLE
feat: maintain cumulative actress scrape status on the detail page (#19)

### DIFF
--- a/src/main/db/actressRepo.test.ts
+++ b/src/main/db/actressRepo.test.ts
@@ -255,6 +255,22 @@ describe('actressRepo.clearActressMetadataRecord', () => {
       .get() as { c: number }
     assert.equal(links.c, 1)
   })
+
+  it('resets every cumulative state to unscraped and drops the success time', () => {
+    setupDb()
+    markActressScrapeSucceeded(1)
+    recordActressScrapeFailure(2)
+
+    clearActressMetadataRecord(1)
+    clearActressMetadataRecord(2)
+    clearActressMetadataRecord(3)
+
+    for (const id of [1, 2, 3]) {
+      const detail = getActressDetail(id)
+      assert.equal(detail?.scraped_status, 0)
+      assert.equal(detail?.last_scraped_at, null)
+    }
+  })
 })
 
 describe('actressRepo.deleteUnlinkedActresses', () => {

--- a/src/main/db/actressRepo.test.ts
+++ b/src/main/db/actressRepo.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { createAvatarCropV1, parseAvatarCrop } from '@shared/avatarCrop'
+import type { ScrapedStatus } from '@shared/types'
 import { closeDatabase, getDb, initDatabaseAtPath } from './database'
 import { insertTestVideoWithFile } from './testVideoFixtures'
 import {
@@ -110,6 +111,43 @@ function setupDb(): void {
      VALUES (?, 'gallery', 0, ?, ?, ?)`
   ).run(1, 'https://example.test/complete.jpg', 'actress_gallery/complete.jpg', 'now')
 }
+
+function setActressScrapeRecord(
+  id: number,
+  status: ScrapedStatus,
+  lastScrapedAt: string | null
+): void {
+  getDb()
+    .prepare('UPDATE actresses SET scraped_status = ?, last_scraped_at = ? WHERE id = ?')
+    .run(status, lastScrapedAt, id)
+}
+
+const ACTRESS_SCRAPE_STATUS_LABEL: Record<ScrapedStatus, string> = {
+  0: '未刮削',
+  1: '刮削成功',
+  2: '刮削失败'
+}
+
+const KEEPER_SUCCESS_TIME = '2023-03-03T00:00:00.000Z'
+const MERGED_SUCCESS_TIME = '2024-04-04T00:00:00.000Z'
+
+/** Every pairing of cumulative states, with the history the keeper must end up with. */
+const MERGE_SCRAPE_STATUS_MATRIX: Array<{
+  keep: ScrapedStatus
+  merge: ScrapedStatus
+  status: ScrapedStatus
+  lastScrapedAt: string | null
+}> = [
+  { keep: 0, merge: 0, status: 0, lastScrapedAt: null },
+  { keep: 0, merge: 2, status: 2, lastScrapedAt: null },
+  { keep: 0, merge: 1, status: 1, lastScrapedAt: MERGED_SUCCESS_TIME },
+  { keep: 2, merge: 0, status: 2, lastScrapedAt: null },
+  { keep: 2, merge: 2, status: 2, lastScrapedAt: null },
+  { keep: 2, merge: 1, status: 1, lastScrapedAt: MERGED_SUCCESS_TIME },
+  { keep: 1, merge: 0, status: 1, lastScrapedAt: KEEPER_SUCCESS_TIME },
+  { keep: 1, merge: 2, status: 1, lastScrapedAt: KEEPER_SUCCESS_TIME },
+  { keep: 1, merge: 1, status: 1, lastScrapedAt: MERGED_SUCCESS_TIME }
+]
 
 afterEach(() => {
   closeDatabase()
@@ -356,6 +394,44 @@ describe('actressRepo.mergeActresses', () => {
     assert.ok(detail)
     assert.equal(detail.main_name, 'Missing Female')
     assert.ok(detail.aliases.includes('Complete'))
+  })
+
+  for (const merged of MERGE_SCRAPE_STATUS_MATRIX) {
+    const keeperLabel = ACTRESS_SCRAPE_STATUS_LABEL[merged.keep]
+    const mergedLabel = ACTRESS_SCRAPE_STATUS_LABEL[merged.merge]
+    it(`keeps ${ACTRESS_SCRAPE_STATUS_LABEL[merged.status]} when merging ${mergedLabel} into ${keeperLabel}`, () => {
+      setupDb()
+      setActressScrapeRecord(1, merged.keep, merged.keep === 1 ? KEEPER_SUCCESS_TIME : null)
+      setActressScrapeRecord(2, merged.merge, merged.merge === 1 ? MERGED_SUCCESS_TIME : null)
+
+      mergeActresses(1, 2, 'keep')
+
+      const detail = getActressDetail(1)
+      assert.equal(detail?.scraped_status, merged.status)
+      assert.equal(detail?.last_scraped_at, merged.lastScrapedAt)
+    })
+  }
+
+  it('keeps the newer success time when the keeper succeeded more recently', () => {
+    setupDb()
+    setActressScrapeRecord(1, 1, '2025-05-05T00:00:00.000Z')
+    setActressScrapeRecord(2, 1, '2024-04-04T00:00:00.000Z')
+
+    mergeActresses(1, 2, 'keep')
+
+    assert.equal(getActressDetail(1)?.last_scraped_at, '2025-05-05T00:00:00.000Z')
+  })
+
+  it('ignores a success time left on a record that is not scraped successfully', () => {
+    setupDb()
+    setActressScrapeRecord(1, 2, '2019-09-09T00:00:00.000Z')
+    setActressScrapeRecord(2, 1, '2018-08-08T00:00:00.000Z')
+
+    mergeActresses(1, 2, 'keep')
+
+    const detail = getActressDetail(1)
+    assert.equal(detail?.scraped_status, 1)
+    assert.equal(detail?.last_scraped_at, '2018-08-08T00:00:00.000Z')
   })
 })
 

--- a/src/main/db/actressRepo.test.ts
+++ b/src/main/db/actressRepo.test.ts
@@ -8,6 +8,7 @@ import type { ScrapedStatus } from '@shared/types'
 import { closeDatabase, getDb, initDatabaseAtPath } from './database'
 import { insertTestVideoWithFile } from './testVideoFixtures'
 import {
+  addActressGalleryAsset,
   applyActressScrapeResult,
   clearActressMetadataRecord,
   clearBrokenActressAvatarIfNeeded,
@@ -869,6 +870,54 @@ describe('actressRepo cumulative scrape status', () => {
     assert.equal(detail.last_scraped_at, null)
     assert.ok(detail.avatar_path)
   })
+})
+
+describe('actressRepo cumulative scrape status maintenance invariants', () => {
+  for (const status of [0, 1, 2] as ScrapedStatus[]) {
+    const successTime = status === 1 ? '2022-02-02T00:00:00.000Z' : null
+    it(`keeps ${ACTRESS_SCRAPE_STATUS_LABEL[status]} and its success time through manual maintenance`, () => {
+      setupDb()
+      const db = getDb()
+      setActressScrapeRecord(1, status, successTime)
+      writeTestAsset('actress_gallery/maintenance.jpg', MINIMAL_JPEG)
+
+      editActress(1, {
+        main_name: 'Maintained',
+        birth_date: '1991-02-03',
+        profile_summary: 'Manually maintained',
+        aliases: ['Maintained Alias']
+      })
+      setActressAvatarBundle(1, 'Maintained', {
+        displayImageBase64: MINIMAL_JPEG.toString('base64'),
+        sourceImageBase64: MINIMAL_JPEG.toString('base64'),
+        crop: createAvatarCropV1({
+          sourceFingerprint: avatarSourceFingerprint(MINIMAL_JPEG),
+          zoom: 1.4,
+          offsetX: 2,
+          offsetY: -2
+        })
+      })
+      const added = addActressGalleryAsset(1, {
+        remoteUrl: 'https://example.test/maintenance.jpg',
+        localPath: 'actress_gallery/maintenance.jpg'
+      })
+      setActressPosterPath(1, 'actress_gallery/maintenance.jpg')
+      setActressPosterPath(1, null)
+      deleteActressGalleryAsset(1, added.id)
+      insertTestVideoWithFile(db, {
+        code: 'MAINT-001',
+        filePath: 'maint.mp4',
+        title: 'Maintenance',
+        addTime: '2024-01-01'
+      })
+      db.prepare('INSERT INTO video_actress (video_id, actress_id) VALUES (?, ?)').run(1, 1)
+      upsertActressFromScrape('Maintained', null, 'female')
+
+      const detail = getActressDetail(1)
+      assert.equal(detail?.scraped_status, status)
+      assert.equal(detail?.last_scraped_at, successTime)
+    })
+  }
 })
 
 describe('actressRepo.upsertActressFromScrape avatar adopt', () => {

--- a/src/main/db/actressRepo.test.ts
+++ b/src/main/db/actressRepo.test.ts
@@ -17,6 +17,7 @@ import {
   editActress,
   listActresses,
   listActressesForBatchScrape,
+  markActressScrapeSucceeded,
   mergeActresses,
   getActressAvatarSourceInfo,
   getActressDetail,
@@ -900,6 +901,59 @@ describe('actressRepo.recordActressScrapeFailure', () => {
     assert.equal(detail?.scraped_status, 2)
     assert.equal(detail?.last_scraped_at, null)
     assert.equal(detail?.birth_date, null)
+  })
+})
+
+describe('actressRepo.markActressScrapeSucceeded', () => {
+  it('promotes an unscraped actress and stamps the missing success time', () => {
+    setupDb()
+
+    markActressScrapeSucceeded(2)
+
+    const detail = getActressDetail(2)
+    assert.equal(detail?.scraped_status, 1)
+    assert.ok(detail?.last_scraped_at)
+  })
+
+  it('promotes a failed actress and stamps the missing success time', () => {
+    setupDb()
+    recordActressScrapeFailure(2)
+
+    markActressScrapeSucceeded(2)
+
+    const detail = getActressDetail(2)
+    assert.equal(detail?.scraped_status, 1)
+    assert.ok(detail?.last_scraped_at)
+  })
+
+  it('keeps an existing success time instead of restamping it', () => {
+    setupDb()
+    getDb()
+      .prepare('UPDATE actresses SET scraped_status = 1, last_scraped_at = ? WHERE id = ?')
+      .run('2020-01-02T03:04:05.000Z', 2)
+
+    markActressScrapeSucceeded(2)
+
+    const detail = getActressDetail(2)
+    assert.equal(detail?.scraped_status, 1)
+    assert.equal(detail?.last_scraped_at, '2020-01-02T03:04:05.000Z')
+  })
+
+  it('stamps a success time over a blank stored time', () => {
+    setupDb()
+    getDb().prepare('UPDATE actresses SET last_scraped_at = ? WHERE id = ?').run('   ', 2)
+
+    markActressScrapeSucceeded(2)
+
+    const detail = getActressDetail(2)
+    assert.equal(detail?.scraped_status, 1)
+    assert.ok(detail?.last_scraped_at?.trim())
+  })
+
+  it('rejects marking an actress that does not exist', () => {
+    setupDb()
+
+    assert.throws(() => markActressScrapeSucceeded(9999), /演员不存在/)
   })
 })
 

--- a/src/main/db/actressRepo.ts
+++ b/src/main/db/actressRepo.ts
@@ -1031,14 +1031,12 @@ function mergeActressScrapeRecords(
     ACTRESS_SCRAPE_STATUS_STRENGTH[keep.scraped_status]
       ? merge.scraped_status
       : keep.scraped_status
-  const successTimes = [keep, merge]
-    .filter((record) => record.scraped_status === 1 && !isBlankText(record.last_scraped_at))
-    .map((record) => record.last_scraped_at as string)
-  const lastScrapedAt = successTimes.reduce<string | null>(
-    (newest, time) => (newest === null || time > newest ? time : newest),
-    null
-  )
-  return { scrapedStatus, lastScrapedAt }
+  const [newestSuccessTime] = [keep, merge]
+    .filter((record) => record.scraped_status === 1)
+    .map((record) => record.last_scraped_at)
+    .filter((time): time is string => !isBlankText(time))
+    .sort((a, b) => (a > b ? -1 : 1))
+  return { scrapedStatus, lastScrapedAt: newestSuccessTime ?? null }
 }
 
 /**

--- a/src/main/db/actressRepo.ts
+++ b/src/main/db/actressRepo.ts
@@ -1040,7 +1040,7 @@ export function clearActressMetadataRecord(id: number): void {
          blood_type = NULL, zodiac = NULL, nationality = NULL,
          profile_summary = NULL, avatar_path = NULL, avatar_source_path = NULL,
          avatar_crop_json = NULL, poster_path = NULL,
-         last_scraped_at = NULL, updated_at = ?
+         scraped_status = 0, last_scraped_at = NULL, updated_at = ?
        WHERE id = ?`
     ).run(nowIso(), id)
     db.prepare("DELETE FROM actress_names WHERE actress_id = ? AND type != 'main'").run(id)

--- a/src/main/db/actressRepo.ts
+++ b/src/main/db/actressRepo.ts
@@ -1377,6 +1377,22 @@ export function recordActressScrapeFailure(actressId: number): void {
   ).run(nowIso(), actressId)
 }
 
+/** Manually confirm a scrape succeeded. An earlier success time is kept, a missing one is stamped. */
+export function markActressScrapeSucceeded(actressId: number): void {
+  const db = getDb()
+  const scrapedAt = nowIso()
+  const result = db
+    .prepare(
+      `UPDATE actresses
+       SET scraped_status = 1,
+           last_scraped_at = COALESCE(NULLIF(trim(last_scraped_at), ''), @scrapedAt),
+           updated_at = @scrapedAt
+       WHERE id = @actressId`
+    )
+    .run({ actressId, scrapedAt })
+  if (result.changes === 0) throw new Error('演员不存在')
+}
+
 function hasValidActressScrapeValue(
   result: ActressScrapeResult,
   field: ActressScrapeField,

--- a/src/main/db/actressRepo.ts
+++ b/src/main/db/actressRepo.ts
@@ -18,7 +18,8 @@ import type {
   ActressListSortBy,
   ActressAvatarSourceInfo,
   ActressMergeMainNameFrom,
-  ListSortDir
+  ListSortDir,
+  ScrapedStatus
 } from '@shared/types'
 import { ALL_ACTRESS_SCRAPE_FIELDS, ACTRESS_BATCH_DEFAULT_MISSING_FIELDS } from '@shared/types'
 import {
@@ -891,6 +892,7 @@ export function mergeActresses(
   const mergeAvatarPath = merge.avatar_path
   const mergeAvatarSourcePath = merge.avatar_source_path
   const keepHadAvatar = !isBlankText(keep.avatar_path)
+  const mergedScrapeRecord = mergeActressScrapeRecords(keep, merge)
 
   const txn = db.transaction(() => {
     db.prepare(
@@ -954,12 +956,8 @@ export function mergeActresses(
            ELSE avatar_crop_json
          END,
          gender = COALESCE(gender, @gender),
-         last_scraped_at = CASE
-           WHEN last_scraped_at IS NULL THEN @last_scraped_at
-           WHEN @last_scraped_at IS NULL THEN last_scraped_at
-           WHEN last_scraped_at > @last_scraped_at THEN last_scraped_at
-           ELSE @last_scraped_at
-         END,
+         scraped_status = @scraped_status,
+         last_scraped_at = @last_scraped_at,
          updated_at = @updated_at
        WHERE id = @keepId`
     ).run({
@@ -980,7 +978,8 @@ export function mergeActresses(
       avatar_crop_json: merge.avatar_crop_json,
       keep_had_avatar: keepHadAvatar ? 1 : 0,
       gender: merge.gender,
-      last_scraped_at: merge.last_scraped_at,
+      scraped_status: mergedScrapeRecord.scrapedStatus,
+      last_scraped_at: mergedScrapeRecord.lastScrapedAt,
       updated_at: nowIso()
     })
 
@@ -1015,6 +1014,31 @@ export function mergeActresses(
     if (mergeAvatarPath && mergeAvatarPath !== keptAvatar) deleteAsset(mergeAvatarPath)
     if (mergeAvatarSourcePath) deleteAsset(mergeAvatarSourcePath)
   }
+}
+
+/** Cumulative history is strongest for a success, then a failure, and weakest when never scraped. */
+const ACTRESS_SCRAPE_STATUS_STRENGTH: Record<ScrapedStatus, number> = { 0: 0, 2: 1, 1: 2 }
+
+type ActressScrapeRecord = Pick<Actress, 'scraped_status' | 'last_scraped_at'>
+
+/** Combine two cumulative histories: the strongest state wins, and only successes contribute a time. */
+function mergeActressScrapeRecords(
+  keep: ActressScrapeRecord,
+  merge: ActressScrapeRecord
+): { scrapedStatus: ScrapedStatus; lastScrapedAt: string | null } {
+  const scrapedStatus =
+    ACTRESS_SCRAPE_STATUS_STRENGTH[merge.scraped_status] >
+    ACTRESS_SCRAPE_STATUS_STRENGTH[keep.scraped_status]
+      ? merge.scraped_status
+      : keep.scraped_status
+  const successTimes = [keep, merge]
+    .filter((record) => record.scraped_status === 1 && !isBlankText(record.last_scraped_at))
+    .map((record) => record.last_scraped_at as string)
+  const lastScrapedAt = successTimes.reduce<string | null>(
+    (newest, time) => (newest === null || time > newest ? time : newest),
+    null
+  )
+  return { scrapedStatus, lastScrapedAt }
 }
 
 /**

--- a/src/main/ipc/actressHandlers.ts
+++ b/src/main/ipc/actressHandlers.ts
@@ -19,6 +19,7 @@ import {
   getActressDetail,
   getActressAvatarSourceInfo,
   listActresses,
+  markActressScrapeSucceeded,
   mergeActresses,
   setActressPosterPath
 } from '../db/actressRepo'
@@ -70,6 +71,11 @@ export function registerActressHandlers(): void {
 
   registerHandler(IPC.ACTRESS_MERGE, (_e, input: ActressMergeInput): boolean => {
     mergeActresses(input.keepId, input.mergeId, input.mainNameFrom)
+    return true
+  })
+
+  registerHandler(IPC.ACTRESS_MARK_SCRAPE_SUCCESS, (_e, id: number): boolean => {
+    markActressScrapeSucceeded(id)
     return true
   })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -188,7 +188,8 @@ const api = {
       invoke<boolean>(IPC.ACTRESS_GALLERY_DELETE, id, assetId),
     setPoster: (id: number, posterPath: string | null) =>
       invoke<boolean>(IPC.ACTRESS_POSTER_SET, id, posterPath),
-    merge: (input: ActressMergeInput) => invoke<boolean>(IPC.ACTRESS_MERGE, input)
+    merge: (input: ActressMergeInput) => invoke<boolean>(IPC.ACTRESS_MERGE, input),
+    markScrapeSuccess: (id: number) => invoke<boolean>(IPC.ACTRESS_MARK_SCRAPE_SUCCESS, id)
   },
   tags: {
     list: () =>

--- a/src/renderer/src/components/ActressProfileMeta.test.ts
+++ b/src/renderer/src/components/ActressProfileMeta.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildActressScrapeMetaItems } from './ActressProfileMeta'
+import { buildActressScrapeMetaItems, canMarkActressScrapeSuccess } from './ActressProfileMeta'
 
 describe('ActressProfileMeta scrape record', () => {
   it('shows all cumulative states and only includes a non-blank success time', () => {
@@ -19,5 +19,11 @@ describe('ActressProfileMeta scrape record', () => {
       buildActressScrapeMetaItems({ scraped_status: 2, last_scraped_at: '   ' }),
       [{ key: 'scraped_status', label: '刮削状态', value: '刮削失败', status: 2 }]
     )
+  })
+
+  it('offers the manual success mark only for unscraped and failed records', () => {
+    assert.equal(canMarkActressScrapeSuccess(0), true)
+    assert.equal(canMarkActressScrapeSuccess(2), true)
+    assert.equal(canMarkActressScrapeSuccess(1), false)
   })
 })

--- a/src/renderer/src/components/ActressProfileMeta.tsx
+++ b/src/renderer/src/components/ActressProfileMeta.tsx
@@ -65,6 +65,11 @@ const ACTRESS_SCRAPE_STATUS_PRESENTATION: Record<
   2: { label: '刮削失败', className: 'detail-meta-status--failed' }
 }
 
+/** Cumulative success is sticky, so only unscraped and failed records can be marked manually. */
+export function canMarkActressScrapeSuccess(status: ScrapedStatus): boolean {
+  return status !== 1
+}
+
 export function buildActressScrapeMetaItems(
   actress: Pick<ActressDetail, 'scraped_status' | 'last_scraped_at'>
 ): MetaItem[] {

--- a/src/renderer/src/pages/ActressDetailPage.tsx
+++ b/src/renderer/src/pages/ActressDetailPage.tsx
@@ -28,7 +28,8 @@ import ActressAvatar from '../components/ActressAvatar'
 import ActressGalleryPanel from '../components/ActressGalleryPanel'
 import ActressProfileMeta, {
   buildActressProfileStats,
-  buildActressProfileSubtitle
+  buildActressProfileSubtitle,
+  canMarkActressScrapeSuccess
 } from '../components/ActressProfileMeta'
 import DetailScrollBody from '../components/DetailScrollBody'
 import ImagePreviewLightbox from '../components/ImagePreviewLightbox'
@@ -243,6 +244,17 @@ export default function ActressDetailPage(): JSX.Element {
     }
   }
 
+  const handleMarkScrapeSuccess = async (): Promise<void> => {
+    try {
+      await api.actresses.markScrapeSuccess(actressId)
+      toast.show('已标记为刮削成功', 'success')
+      invalidateActressLibraryQueries(queryClient)
+      await load({ silent: true })
+    } catch (e) {
+      toast.show(String((e as Error).message), 'error')
+    }
+  }
+
   const doClearMeta = async (): Promise<void> => {
     try {
       await api.actresses.clearMeta(actressId)
@@ -352,6 +364,14 @@ export default function ActressDetailPage(): JSX.Element {
           key: 'merge',
           label: '合并演员',
           onClick: () => setShowMerge(true)
+        },
+        {
+          key: 'mark-success',
+          label: '标记为刮削成功',
+          hidden: !canMarkActressScrapeSuccess(actress.scraped_status),
+          onClick: () => {
+            void handleMarkScrapeSuccess()
+          }
         },
         { key: 'danger-separator', type: 'separator' },
         {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -68,6 +68,7 @@ export const IPC = {
   ACTRESS_GALLERY_DELETE: 'actress:galleryDelete',
   ACTRESS_POSTER_SET: 'actress:posterSet',
   ACTRESS_MERGE: 'actress:merge',
+  ACTRESS_MARK_SCRAPE_SUCCESS: 'actress:markScrapeSuccess',
 
   // Tags
   TAG_LIST: 'tag:list',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #19 (part of the #16 spec: 统一演员与影片的累计刮削状态). Built in parallel with #20 and #21.

## What changed
- `actressRepo`: new `markActressScrapeSucceeded` (promotes 未刮削/刮削失败 → 刮削成功, stamps a success time only when none exists, throws `演员不存在`); `clearActressMetadataRecord` now resets `scraped_status = 0`; `mergeActresses` resolves surviving history via `mergeActressScrapeRecords` (刮削成功 > 刮削失败 > 未刮削, newest time among success records only).
- New IPC `ACTRESS_MARK_SCRAPE_SUCCESS` → `preload actresses.markScrapeSuccess(id)` → handler in `actressHandlers`.
- `ActressDetailPage`: `标记为刮削成功` menu item (hidden for success records) + toast + unified library/overview cache invalidation + detail reload. `ActressProfileMeta` exports `canMarkActressScrapeSuccess(status)` (testable eligibility rule).

## Tests
- `actressRepo.test.ts`: manual-mark (5), clear-metadata reset, full 3×3 merge matrix (9) + newer-time / stray-time cases, and maintenance invariants (profile edit, avatar, gallery, poster, video link, scrape upsert) per state (mutation-checked, not vacuous).
- `ActressProfileMeta.test.ts`: eligibility contract.

## Gates (all green)
- `npm test`: 372 pass / 0 fail
- `npm run typecheck:web`: clean
- `npm run check:encoding`: passed
- `npm run build`: ✓

## Notes
- Edits to shared wiring files (`actressRepo.ts`, `ipc-channels.ts`, `preload/index.ts`) are additive to keep integration merges with #20/#21 trivial.
- GUI smoke of the detail menu is deferred to integration (single shared display in the VM); logic is covered by the contract test + repo lifecycle test.
- Flagged (pre-existing, not this PR): `actressRepo.test.ts › replace adopts a new avatar when scraped bytes differ from existing source` is flaky on clean `dev` because avatar filenames mix in `Date.now()`; worth its own ticket.

Closes #19
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3bba163-d563-4e16-8ff7-c5e6cc79b89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3bba163-d563-4e16-8ff7-c5e6cc79b89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

