### PR TITLE
feat: 统一演员三态概览与跨页面刷新 (#23)

### DIFF
--- a/src/main/db/overviewRepo.test.ts
+++ b/src/main/db/overviewRepo.test.ts
@@ -16,9 +16,31 @@ function setupDb(): void {
   insertTestVideoWithFile(db, { code: 'A-1', filePath: 'a.mp4', scrapedStatus: 1 })
   insertTestVideoWithFile(db, { code: 'B-1', filePath: 'b.mp4', scrapedStatus: 0 })
   insertTestVideoWithFile(db, { code: 'C-1', filePath: 'c.mp4', scrapedStatus: 2 })
-  db.prepare(`INSERT INTO actresses (main_name, gender) VALUES ('Alice', 'female')`).run()
-  db.prepare(`INSERT INTO actresses (main_name, gender) VALUES ('Bob', 'male')`).run()
-  db.prepare(`UPDATE actresses SET last_scraped_at = '2024-01-01T00:00:00.000Z' WHERE main_name = 'Alice'`).run()
+
+  // Female scope covers cumulative three-state; male is counted but outside coverage.
+  db.prepare(
+    `INSERT INTO actresses (main_name, gender, scraped_status, last_scraped_at)
+     VALUES ('Alice', 'female', 1, '2024-01-01T00:00:00.000Z')`
+  ).run()
+  db.prepare(
+    `INSERT INTO actresses (main_name, gender, scraped_status, last_scraped_at)
+     VALUES ('Carol', 'female', 0, NULL)`
+  ).run()
+  // Failed with no success time — must still count as failed, not unscraped.
+  db.prepare(
+    `INSERT INTO actresses (main_name, gender, scraped_status, last_scraped_at)
+     VALUES ('Dana', 'female', 2, NULL)`
+  ).run()
+  // Stale timestamp must not make an unscraped actress look successful.
+  db.prepare(
+    `INSERT INTO actresses (main_name, gender, scraped_status, last_scraped_at)
+     VALUES ('Eve', NULL, 0, '2023-06-01T00:00:00.000Z')`
+  ).run()
+  db.prepare(
+    `INSERT INTO actresses (main_name, gender, scraped_status, last_scraped_at)
+     VALUES ('Bob', 'male', 1, '2024-02-01T00:00:00.000Z')`
+  ).run()
+
   db.prepare(`INSERT INTO tags (name) VALUES ('Drama')`).run()
   db.prepare(`INSERT INTO playlists (name) VALUES ('Favorites')`).run()
   db.prepare(
@@ -40,15 +62,38 @@ describe('getLibraryOverviewStats', () => {
     const stats = getLibraryOverviewStats()
     assert.deepEqual(stats.videos, { total: 3, scraped: 1, unscraped: 1, failed: 1 })
     assert.deepEqual(stats.actresses, {
-      total: 2,
-      female: 1,
+      total: 5,
+      female: 4,
       male: 1,
       scraped: 1,
-      unscraped: 0
+      failed: 1,
+      unscraped: 2
     })
+    assert.equal(
+      stats.actresses.scraped + stats.actresses.failed + stats.actresses.unscraped,
+      stats.actresses.female
+    )
     assert.equal(stats.playlists, 1)
     assert.equal(stats.tags, 1)
     assert.equal(stats.galleryAssets, 0)
     assert.deepEqual(stats.facets, { directors: 1, makers: 0, publishers: 0, series: 0 })
+  })
+
+  it('counts actress cumulative status from scraped_status, not last_scraped_at', () => {
+    setupDb()
+    const db = getDb()
+    // Promote Carol to failed without writing a success time.
+    db.prepare(`UPDATE actresses SET scraped_status = 2 WHERE main_name = 'Carol'`).run()
+    // Clear Alice's success time while keeping scraped_status = success.
+    db.prepare(`UPDATE actresses SET last_scraped_at = NULL WHERE main_name = 'Alice'`).run()
+
+    const stats = getLibraryOverviewStats()
+    assert.equal(stats.actresses.scraped, 1)
+    assert.equal(stats.actresses.failed, 2)
+    assert.equal(stats.actresses.unscraped, 1)
+    assert.equal(
+      stats.actresses.scraped + stats.actresses.failed + stats.actresses.unscraped,
+      stats.actresses.female
+    )
   })
 })

--- a/src/main/db/overviewRepo.ts
+++ b/src/main/db/overviewRepo.ts
@@ -23,16 +23,32 @@ export function getLibraryOverviewStats(): LibraryOverviewStats {
               SUM(CASE WHEN gender IS NULL OR gender = 'female' THEN 1 ELSE 0 END) AS female,
               SUM(
                 CASE
-                  WHEN (gender IS NULL OR gender = 'female')
-                    AND last_scraped_at IS NOT NULL
-                    AND trim(last_scraped_at) != ''
-                  THEN 1
+                  WHEN (gender IS NULL OR gender = 'female') AND scraped_status = 1 THEN 1
                   ELSE 0
                 END
-              ) AS scraped
+              ) AS scraped,
+              SUM(
+                CASE
+                  WHEN (gender IS NULL OR gender = 'female') AND scraped_status = 2 THEN 1
+                  ELSE 0
+                END
+              ) AS failed,
+              SUM(
+                CASE
+                  WHEN (gender IS NULL OR gender = 'female') AND scraped_status = 0 THEN 1
+                  ELSE 0
+                END
+              ) AS unscraped
        FROM actresses`
     )
-    .get() as { total: number; male: number; female: number; scraped: number }
+    .get() as {
+    total: number
+    male: number
+    female: number
+    scraped: number
+    failed: number
+    unscraped: number
+  }
 
   const playlists = (db.prepare('SELECT COUNT(*) AS n FROM playlists').get() as { n: number }).n
   const tags = (db.prepare('SELECT COUNT(*) AS n FROM tags').get() as { n: number }).n
@@ -60,7 +76,8 @@ export function getLibraryOverviewStats(): LibraryOverviewStats {
       female: actressRow.female,
       male: actressRow.male,
       scraped: actressRow.scraped,
-      unscraped: actressRow.female - actressRow.scraped
+      failed: actressRow.failed,
+      unscraped: actressRow.unscraped
     },
     playlists,
     tags,

--- a/src/renderer/src/components/settings/SettingsOverviewPanel.tsx
+++ b/src/renderer/src/components/settings/SettingsOverviewPanel.tsx
@@ -638,6 +638,7 @@ export default function SettingsOverviewPanel({
           <ScrapeCoverageBlock
             scraped={actressScraped}
             unscraped={stats?.actresses.unscraped ?? 0}
+            failed={stats?.actresses.failed ?? 0}
             total={actressFemaleTotal}
             title="刮削覆盖 · 女优"
           />

--- a/src/renderer/src/pages/ActressDetailPage.tsx
+++ b/src/renderer/src/pages/ActressDetailPage.tsx
@@ -260,6 +260,7 @@ export default function ActressDetailPage(): JSX.Element {
       await api.actresses.clearMeta(actressId)
       setConfirmClear(false)
       toast.show('已清除元数据', 'success')
+      invalidateActressLibraryQueries(queryClient)
       void load({ silent: true })
     } catch (e) {
       toast.show(String((e as Error).message), 'error')
@@ -566,6 +567,7 @@ export default function ActressDetailPage(): JSX.Element {
           onMerged={() => {
             setShowMerge(false)
             toast.show('演员已合并', 'success')
+            invalidateActressLibraryQueries(queryClient)
             void load({ silent: true })
           }}
         />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1282,9 +1282,11 @@ export interface LibraryOverviewStats {
     total: number
     female: number
     male: number
-    /** Female performers with a scrape timestamp. */
+    /** Female performers with cumulative 刮削成功. */
     scraped: number
-    /** Female performers without a scrape timestamp. */
+    /** Female performers with cumulative 刮削失败. */
+    failed: number
+    /** Female performers with cumulative 未刮削. */
     unscraped: number
   }
   playlists: number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- 设置概览女优覆盖改为按 `scraped_status` 统计刮削成功 / 失败 / 未刮削，三者之和等于女优总数。
- 复用现有三段覆盖条，正确传入失败数量；不再用 `last_scraped_at` 近似累计状态。
- 清除元数据与合并演员后走统一的 `invalidateActressLibraryQueries`，与单次刮削、手动标记、批量任务一致刷新演员库与概览。

## Test plan

- [x] `overviewRepo` 三态统计与“不以时间为准”回归测试
- [x] `npm run typecheck`
- [x] `npm test`（414 passed）
- [x] `npm run check:encoding`
- [x] `npm run build`
- [x] 应用冒烟：状态 URL、演员库筛选/选择、详情手动标记、高级刮削四态、暂停恢复、概览刷新

Closes #23
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-062ede52-5cca-4237-8d86-923d0f645393?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-062ede52-5cca-4237-8d86-923d0f645393&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

